### PR TITLE
Updated .NET HttpClient to disable the proxy

### DIFF
--- a/dino-dotnet/Program.cs
+++ b/dino-dotnet/Program.cs
@@ -13,7 +13,7 @@ namespace dino_dotnet
         {
             Console.WriteLine("start");
 
-            HttpClient client = new HttpClient(new HttpClientHandler()
+            HttpClient httpClient = new HttpClient(new HttpClientHandler()
             {
                 UseProxy = false,
                 Proxy = null
@@ -24,19 +24,16 @@ namespace dino_dotnet
 
             for (int i = 0; i < 100; i++)
             {
-                DateTime httpDateFirst = DateTime.Now;
-                var response = await client.GetStringAsync("https://raw.githubusercontent.com/tsopenteam/gundem/master/gundem.json");
-                DateTime httpDateLast = DateTime.Now;
+                var httpStopwatch = Stopwatch.StartNew();
+                var response = await httpClient.GetStringAsync("https://raw.githubusercontent.com/tsopenteam/gundem/master/gundem.json").ConfigureAwait(false);
+                httpStopwatch.Stop();
 
-                DateTime jsonDateFirst = DateTime.Now;
+                var jsonStopwatch = Stopwatch.StartNew();
                 var result = JSON.DeserializeDynamic(response);
-                DateTime jsonDateLast = DateTime.Now;
+                jsonStopwatch.Stop();
 
-                TimeSpan httpTime = httpDateLast - httpDateFirst;
-                TimeSpan jsonTime = jsonDateLast - jsonDateFirst;
-
-                httpTimeList.Add(httpTime.TotalSeconds);
-                jsonTimeList.Add(jsonTime.TotalSeconds);
+                httpTimeList.Add(httpStopwatch.Elapsed.TotalSeconds);
+                jsonTimeList.Add(jsonStopwatch.Elapsed.TotalSeconds);
 
                 Console.WriteLine($"{i + 1} Http : {httpTimeList[i]}");
                 Console.WriteLine($"{i + 1} Json : {jsonTimeList[i]}");

--- a/dino-dotnet/Program.cs
+++ b/dino-dotnet/Program.cs
@@ -13,8 +13,12 @@ namespace dino_dotnet
         {
             Console.WriteLine("start");
 
-            HttpClient client = new HttpClient();
-
+            HttpClient client = new HttpClient(new HttpClientHandler()
+            {
+                UseProxy = false,
+                Proxy = null
+            });
+            
             List<double> httpTimeList = new List<double>();
             List<double> jsonTimeList = new List<double>();
 


### PR DESCRIPTION
See more information available here:
https://stackoverflow.com/questions/2519655/httpwebrequest-is-extremely-slow

Also added in stopwatch timers.

With this change on my machine the result is:
```
RESULT FOR DOTNET (seconds)
Http First Request Time : 0.2188949
Json First Parse Time : 0.0736177


Http Average Request Time : 0.028942979999999986
Json Average Parse Time : 0.06979647100000001
```

You can run it in the cloud here: https://dotnetfiddle.net/jQmSRO